### PR TITLE
"escavadora" actuator name changed on positioning

### DIFF
--- a/pt_BR.json
+++ b/pt_BR.json
@@ -265,7 +265,7 @@
   "PERCEIVED_INCLINATION": "Inclinação percebida do sensor de inclinação:",
   "PERCEIVED_DIRECTION": "Direção percebida do \"sensor de bússola\":",
   "PERCEIVED_VICTIM": "Presença de vítima no atuador:",
-  "BULLDOZER_INCLINATION": "Inclinação do atuador escavadeira:",
+  "BULLDOZER_INCLINATION": "Inclinação do atuador escavadora:",
   "BULLDOZER_BLADE_INCLINATION": "Inclinação do balde:",
   "FORKLIFT_INCLINATION": "Inclinação do atuador empilhadeira:",
   "FORKLIFT_PLATFORM_INCLINATION": "Inclinação da plataforma:",


### PR DESCRIPTION
in sBotics in Portuguese, within the reading of sensors in the Positioning panel, the actuator was described as "Excavator", differing from his name in the robot configurations
![image](https://user-images.githubusercontent.com/34964398/113464686-113eae80-9405-11eb-8768-ecb81dd47d4a.png)

![image](https://user-images.githubusercontent.com/34964398/113464691-1a2f8000-9405-11eb-984c-5a1a7ab11435.png)

this change corrects that