### PR TITLE
Toggle arena markers added

### DIFF
--- a/en.json
+++ b/en.json
@@ -189,6 +189,7 @@
   "ALLOWED_ROBOTS": "Allowed Robots:",
   "NO_VICTIMS": "No. of victims",
   "TILE_PROPERTIES": "Tile properties",
+  "TOGGLE_ARENA_MARKERS": "Enable arena markers",
   "TOGGLE_TIME_LIMIT_END": "Time limit stops code execution",
   "TOGGLE_LACK_OF_PROGRESS": "Lack of progress",
   "TOGGLE_OBSTACLE_PUSHING": "Obstacle pushing",

--- a/pt_BR.json
+++ b/pt_BR.json
@@ -189,6 +189,7 @@
   "ALLOWED_ROBOTS": "Robôs permitidos:",
   "NO_VICTIMS": "N° de vítimas",
   "TILE_PROPERTIES": "Propriedades do ladrilho",
+  "TOGGLE_ARENA_MARKERS": "Ativar marcadores de ladrilho",
   "TOGGLE_TIME_LIMIT_END": "Tempo máximo parar robô",
   "TOGGLE_LACK_OF_PROGRESS": "Falha de progresso",
   "TOGGLE_OBSTACLE_PUSHING": "Empurrar obstáculos",


### PR DESCRIPTION
In both languages ​​of the simulator, the setting to turn on the arena markers was missing the translations, showing the raw version of it

![image](https://user-images.githubusercontent.com/34964398/115283008-3891bd00-a121-11eb-824c-f9e4f885e0e8.png)

I believe this PR solves this, simply by adding these translations
